### PR TITLE
Adds a Node.js HTTP server under /v1/chat/completions for local testing.

### DIFF
--- a/openaimock/README.md
+++ b/openaimock/README.md
@@ -1,0 +1,22 @@
+# Mock OpenAI API
+
+Minimal HTTP server that mimics OpenAI's `/v1/chat/completions` endpoint so you can test `secure-llm-gateway` without using your real API key.
+
+## Usage
+
+```bash
+npm install # optional, there are no external dependencies
+npm start
+```
+
+The server listens by default on `http://localhost:4000`.
+
+In your main project, override OpenAI's base URL to point to the mock, for example with the environment variable:
+
+```bash
+export OPENAI_BASE_URL="http://localhost:4000"
+```
+
+Then run the gateway and the requests to OpenAI will reach the mock. The server supports both regular responses and streaming (SSE) and returns a sample message.
+
+You can modify `server.js` to customize the text you want to return.

--- a/openaimock/package.json
+++ b/openaimock/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mock-openai-api",
+  "version": "1.0.0",
+  "description": "Simple mock server that emulates the OpenAI chat completions streaming endpoint.",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/openaimock/server.js
+++ b/openaimock/server.js
@@ -1,0 +1,142 @@
+// server.js - Mock OpenAI with first-byte delay (forces 504 in the gateway)
+import http from 'http';
+import { randomUUID } from 'crypto';
+
+const PORT = Number(process.env.PORT ?? 4000);
+// Set this > TIMEOUT_SECS*1000 in the gateway to trigger a 504, e.g. 5000 if TIMEOUT_SECS=2
+const LATENCY_MS = Number(process.env.LATENCY_MS ?? 0);
+
+const MOCK_REPLY = "Hi, I am a mock OpenAI server. I can help you test your gateway without spending credits.";
+const TOKENS = Array.from(MOCK_REPLY.match(/\s*[^\s]+/g) ?? []);
+
+function logSafe(req, payload, stream) {
+  const sanitizedHeaders = {
+    ...req.headers,
+    authorization: req.headers.authorization ? '[redacted]' : undefined,
+  };
+  console.log('--- Incoming /v1/chat/completions ---');
+  console.log('Headers:', sanitizedHeaders);
+  console.log('Body:', JSON.stringify(payload, null, 2));
+  console.log(`Simulating first-byte latency: ${LATENCY_MS} ms (stream=${stream})`);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/v1/chat/completions') {
+    let body = '';
+
+    req.on('data', (chunk) => { body += chunk; });
+
+    req.on('end', () => {
+      let payload = {};
+      try {
+        payload = body.length ? JSON.parse(body) : {};
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid_json', message: 'Could not parse request body.' }));
+        return;
+      }
+
+      const model = payload.model ?? 'gpt-4o-mini';
+      const created = Math.floor(Date.now() / 1000);
+      const id = `mock-${randomUUID()}`;
+      const stream = Boolean(payload.stream);
+
+      logSafe(req, payload, stream);
+
+      // Do not send ANYTHING before this delay.
+      setTimeout(() => {
+        if (stream) {
+          // ---- STREAMING (SSE) ----
+          console.log('[mock] Sending headers SSE after delay…');
+          res.writeHead(200, {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive',
+          });
+
+          TOKENS.forEach((token, index) => {
+            const chunk = {
+              id,
+              object: 'chat.completion.chunk',
+              created,
+              model,
+              choices: [{
+                index: 0,
+                delta: index === 0 ? { role: 'assistant', content: token } : { content: token },
+                finish_reason: null,
+              }],
+            };
+            setTimeout(() => {
+              try { res.write(`data: ${JSON.stringify(chunk)}\n\n`); } catch {}
+            }, index * 120);
+          });
+
+          const endDelay = TOKENS.length * 120 + 120;
+          setTimeout(() => {
+            try {
+              const finalChunk = {
+                id,
+                object: 'chat.completion.chunk',
+                created,
+                model,
+                choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+              };
+              res.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
+              res.write('data: [DONE]\n\n');
+              res.end();
+            } catch {}
+          }, endDelay);
+
+          return;
+        }
+
+        // ---- NO-STREAM ----
+        const promptTokens = Array.isArray(payload.messages)
+          ? payload.messages.reduce(
+              (acc, msg) => acc + (msg.content?.split(/\s+/).filter(Boolean).length ?? 0),
+              0,
+            )
+          : 0;
+
+        const responseBody = {
+          id,
+          object: 'chat.completion',
+          created,
+          model,
+          choices: [{
+            index: 0,
+            message: { role: 'assistant', content: MOCK_REPLY },
+            finish_reason: 'stop',
+          }],
+          usage: {
+            prompt_tokens: promptTokens,
+            completion_tokens: TOKENS.length,
+            total_tokens: promptTokens + TOKENS.length,
+          },
+        };
+
+        console.log('[mock] Sending headers JSON after delay…');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(responseBody));
+      }, LATENCY_MS);
+    });
+
+    req.on('error', (err) => {
+      console.error('Error receiving request:', err);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+      }
+      res.end(JSON.stringify({ error: 'request_error', message: 'There was a problem reading the request.' }));
+    });
+
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'not_found', message: 'Route not found in the OpenAI mock.' }));
+
+});
+
+server.listen(PORT, () => {
+  console.log(`Mock OpenAI API listening on http://localhost:${PORT} (LATENCY_MS=${LATENCY_MS}ms)`);
+});


### PR DESCRIPTION
# Summary

Adds a local **OpenAI-compatible mock server** to exercise the gateway without spending real credits. It supports **SSE streaming**, **non-stream JSON**, and a configurable **first-byte delay** to reliably trigger **504 Gateway Timeout** scenarios in the gateway.

# What’s Included

* `openaimock/server.js`

  * POST `/v1/chat/completions`
  * `LATENCY_MS` env to delay the **first byte** (applies to both streaming and non-stream).
  * Streams tokens (SSE) or returns a single JSON response.
  * Logs sanitized request headers/body (Authorization redacted).

# Usage

Start the mock upstream:

```bash
# Fast replies (no delay)
LATENCY_MS=0 PORT=4000 node openaimock/server.js

# Slow replies (e.g., 5s first-byte delay)
LATENCY_MS=5000 PORT=4000 node openaimock/server.js
```

# How to Test

**1) Happy path (streaming):**

```bash
curl -N http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "X-Api-Key: demo" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}'
```

**2) Force 504 (first-byte timeout):**

* Run mock with delay: `LATENCY_MS=5000 node openaimock/server.js`
* Set gateway timeout (e.g. `TIMEOUT_SECS=2` in `.env`) and **restart** the gateway.
* Call:

```bash
curl -N http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "X-Api-Key: demo" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}'
```

# Notes

* This mock does **not** validate API keys or enforce quotas; it’s purely for upstream behavior simulation.
