### PR TITLE
Defines a provider abstraction and implements an OpenAI-compatible

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,0 +1,1 @@
+pub mod openai;

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -1,0 +1,161 @@
+use anyhow::Context;
+use futures::{Stream, StreamExt, TryStreamExt};
+use reqwest::{Client, Url};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncBufReadExt;
+use tokio_stream::wrappers::LinesStream;
+use tokio_util::io::StreamReader;
+
+#[derive(Clone)]
+pub struct OpenAIProvider {
+    api_key: String,
+    client: Client,
+    base_url: Url,
+}
+
+impl OpenAIProvider {
+    pub fn new(api_key: String, base_url: Option<String>) -> anyhow::Result<Self> {
+        let base = match base_url {
+            Some(u) if !u.is_empty() => Url::parse(&u)?,
+            _ => Url::parse("https://api.openai.com")?,
+        };
+        let mut builder = Client::builder();
+        if base.scheme() == "https" {
+            builder = builder.http2_prior_knowledge();
+        }
+        let client = builder.build()?;
+        Ok(Self {
+            api_key,
+            client,
+            base_url: base,
+        })
+    }
+
+    pub async fn chat_stream(
+        &self,
+        mut payload: ChatCompletionRequest,
+    ) -> anyhow::Result<impl Stream<Item = anyhow::Result<String>>> {
+        let url = self.base_url.join("/v1/chat/completions")?;
+        // ensure streaming
+        payload.stream = Some(true);
+
+        let res = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .header("Accept", "text/event-stream")
+            .json(&payload)
+            .send()
+            .await
+            .context("openai send failed")?;
+
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!("openai error: {} - {}", status, body));
+        }
+
+        let stream = res
+            .bytes_stream()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+        // Transform into line-based "data: ..." items
+        let s = StreamReader::new(stream);
+        let reader = tokio::io::BufReader::new(s);
+        let lines = reader.lines();
+        let lines = LinesStream::new(lines).map(|l| l.map_err(|e| e.into()));
+        Ok(lines)
+    }
+
+    pub async fn chat_completion(
+        &self,
+        mut payload: ChatCompletionRequest,
+    ) -> anyhow::Result<OpenAIChatCompletionResponse> {
+        let url = self.base_url.join("/v1/chat/completions")?;
+        payload.stream = Some(false);
+
+        let res = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .header("Accept", "application/json")
+            .json(&payload)
+            .send()
+            .await
+            .context("openai send failed")?;
+
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!("openai error: {} - {}", status, body));
+        }
+
+        let body = res
+            .json::<OpenAIChatCompletionResponse>()
+            .await
+            .context("failed to parse openai response")?;
+        Ok(body)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChatMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenAIStreamChunk {
+    pub id: Option<String>,
+    pub choices: Vec<OpenAIChoice>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenAIChoice {
+    pub index: Option<u32>,
+    pub delta: Option<OpenAIDelta>,
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenAIDelta {
+    pub role: Option<String>,
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenAIChatCompletionResponse {
+    pub id: Option<String>,
+    pub object: Option<String>,
+    pub created: Option<i64>,
+    pub model: Option<String>,
+    pub choices: Vec<OpenAIChatCompletionChoice>,
+    pub usage: Option<OpenAIUsage>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenAIChatCompletionChoice {
+    pub index: Option<u32>,
+    pub message: Option<ChatMessage>,
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenAIUsage {
+    pub prompt_tokens: Option<u32>,
+    pub completion_tokens: Option<u32>,
+    pub total_tokens: Option<u32>,
+}


### PR DESCRIPTION
# Summary

Introduce a **provider abstraction** and an **OpenAI-compatible client** that handles both **streaming (SSE)** and **non-stream** chat completions. The streaming API returns a line-oriented stream (`"data: {...}"` / `"data: [DONE]"`) suitable for the gateway’s SSE bridge.

# What’s Included

* `src/provider/mod.rs`

  * Provider module scaffold and public exports.
* `src/provider/openai.rs`

  * `OpenAIProvider` with:

    * `new(api_key, base_url)` (base URL override supported).
    * `chat_stream(ChatCompletionRequest) -> impl Stream<Item = anyhow::Result<String>>`

      * Forces `stream=true`, sets `Accept: text/event-stream`, and yields **lines** (each line is `"data: ..."`) including `[DONE]`.
    * `chat_completion(ChatCompletionRequest) -> OpenAIChatCompletionResponse`

      * Forces `stream=false`, sets `Accept: application/json`.
  * Wire types:

    * `ChatCompletionRequest`, `ChatMessage`
    * Streaming structs: `OpenAIStreamChunk`, `OpenAIChoice`, `OpenAIDelta`
    * Non-stream structs: `OpenAIChatCompletionResponse`, `OpenAIChatCompletionChoice`, `OpenAIUsage`
  * Error handling:

    * Non-2xx upstream → includes status + body in the error for easier debugging.

# Usage

Create a provider and call either streaming or non-stream paths:

```rust
use provider::openai::{OpenAIProvider, ChatCompletionRequest, ChatMessage};
use futures::StreamExt;

let api_key = std::env::var("OPENAI_API_KEY")?;
let base_url = std::env::var("OPENAI_BASE_URL").ok(); // e.g., http://localhost:4000 for the mock
let client = OpenAIProvider::new(api_key, base_url)?;

// 1) Streaming (SSE-like lines: "data: {...}" / "data: [DONE]")
let req = ChatCompletionRequest {
    model: "gpt-4o-mini".into(),
    messages: vec![ChatMessage { role: "user".into(), content: "hello".into() }],
    temperature: None, top_p: None, max_tokens: None, stream: None,
};
let mut s = client.chat_stream(req.clone()).await?;
while let Some(line) = s.next().await {
    let line = line?;
    // parse "data: ..." or detect "data: [DONE]"
    println!("{line}");
}

// 2) Non-stream JSON
let resp = client.chat_completion(req).await?;
println!("completion: {:?}", resp.choices.first());
```

# Notes

* `chat_stream` **intentionally forces** `stream=true` to minimize first-token latency at the proxy layer and keep a single code path.
* The stream yields raw lines (including the `"data: "` prefix). The caller is responsible for detecting `[DONE]` and parsing the JSON payloads.
* Upstream errors surface with both **HTTP status** and **response body** to speed up diagnosis.
* Base URL override allows pointing at **OpenAI-compatible** or **mock** endpoints; future providers (e.g., Claude/Anthropic) can reuse this module pattern without coupling to a single vendor.
