### PR TITLE
Introduces per-tenant quotas backed by Redis TTL counters.

### DIFF
--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,0 +1,86 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use anyhow::Context;
+use redis::aio::ConnectionManager;
+use tokio::sync::Mutex;
+
+use crate::config::AppConfig;
+
+#[derive(Clone)]
+pub struct QuotaManager {
+    conn: Arc<Mutex<ConnectionManager>>,
+    default_quota: u32,
+    window: Duration,
+    overrides: HashMap<String, u32>,
+}
+
+impl QuotaManager {
+    pub async fn maybe_new(cfg: &AppConfig) -> anyhow::Result<Option<Self>> {
+        let Some(url) = cfg.redis_url.as_ref() else {
+            return Ok(None);
+        };
+
+        let client = redis::Client::open(url.clone())
+            .with_context(|| format!("failed to create redis client for {url}"))?;
+        let conn = ConnectionManager::new(client)
+            .await
+            .context("failed to connect to redis")?;
+        Ok(Some(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            default_quota: cfg.default_quota,
+            window: Duration::from_secs(cfg.quota_window_secs),
+            overrides: cfg.tenant_quotas.clone(),
+        }))
+    }
+
+    fn limit_for(&self, tenant: &str) -> u32 {
+        self.overrides
+            .get(tenant)
+            .copied()
+            .unwrap_or(self.default_quota)
+    }
+
+    async fn increment(&self, key: &str) -> Result<i64, redis::RedisError> {
+        let mut conn = self.conn.lock().await;
+        let count: i64 = redis::cmd("INCR").arg(key).query_async(&mut *conn).await?;
+        if count == 1 {
+            let ttl_secs = self.window.as_secs() as usize;
+            let _: () = redis::cmd("EXPIRE")
+                .arg(key)
+                .arg(ttl_secs)
+                .query_async(&mut *conn)
+                .await?;
+        }
+        Ok(count)
+    }
+
+    pub async fn check_and_increment(&self, tenant: &str) -> Result<(), QuotaError> {
+        let limit = self.limit_for(tenant);
+        if limit == 0 {
+            return Err(QuotaError::Exceeded {
+                limit,
+                current: limit,
+            });
+        }
+        let key = format!("quota:{tenant}");
+        let count = self
+            .increment(&key)
+            .await
+            .map_err(|e| QuotaError::Backend(e.into()))?;
+        if count as u32 > limit {
+            return Err(QuotaError::Exceeded {
+                limit,
+                current: count as u32,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum QuotaError {
+    #[error("tenant quota exceeded (limit {limit}, current {current})")]
+    Exceeded { limit: u32, current: u32 },
+    #[error("quota backend error: {0}")]
+    Backend(#[from] anyhow::Error),
+}


### PR DESCRIPTION
# Summary

Add a Redis-backed **QuotaManager** that enforces per-tenant (per `X-Api-Key`) request quotas using fixed windows with TTL counters. Returns an error when the limit is exceeded.

# What’s Included

* `src/quota.rs`

  * `QuotaManager::maybe_new(&AppConfig) -> Option<QuotaManager>`: builds only if `REDIS_URL` is set.
  * Fixed-window counters in Redis with `EXPIRE` on first `INCR`.
  * Per-tenant overrides (`TENANT_QUOTAS`) + global default (`DEFAULT_QUOTA`).
  * Key format: `quota:<tenant>`.
  * `check_and_increment(tenant)`:

    * `INCR quota:<tenant>`; set TTL if count==1.
    * If `count > limit` → `QuotaError::Exceeded { limit, current }`.
  * `QuotaError::{Exceeded, Backend}` to distinguish policy vs backend failures.

# Usage

1. **Configure Redis and quotas** in `.env`:

```ini
REDIS_URL=redis://127.0.0.1:6379/0
DEFAULT_QUOTA=5
QUOTA_WINDOW_SECS=60
TENANT_QUOTAS=tenantA=5,tenantB=8
```

2. **Run Redis** (Docker example):

```bash
docker rm -f redis >/dev/null 2>&1 || true
docker run -d --name redis -p 6379:6379 redis:7-alpine
```

3. The gateway (Part 7) will call:

```rust
if let Some(quota) = state.quota.as_ref() {
    quota.check_and_increment(tenant).await?;
}
```

and mapping `QuotaError::Exceeded` to HTTP **429**.

# Notes

* **Fixed window** semantics: the first request creates the key and sets `EXPIRE` to `QUOTA_WINDOW_SECS`. The counter resets when the TTL elapses.
* Keys are **per tenant** (`quota:<X-Api-Key>`). In distributed deployments, all gateway instances share limits naturally via Redis.
* Setting a tenant override to **0** effectively blocks that tenant (immediate `Exceeded`).
* If Redis is unreachable, you’ll get `QuotaError::Backend` (the HTTP mapping can be 500 in the handler).